### PR TITLE
Fix winner state bug

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,12 +71,15 @@ function App() {
   
   function handleSelectSquare(rowIndex, colIndex) {
 
+    if (gameBoard[rowIndex][colIndex] || winner || hasDraw) {
+      return;
+    }
 
     setGameTurns((prevTurns) => {
       let currentPlayer = deriveActivePlayer(prevTurns);
 
       const updatedTurns = [ {square:{ row: rowIndex, col: colIndex }, player: currentPlayer}, ...prevTurns ];
-      
+
       return updatedTurns;
     });
 


### PR DESCRIPTION
## Summary
- prevent clicking empty squares when game is already over

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840472f6d508330a07d2fb7c699391f