### PR TITLE
Correct player list layout behavior

### DIFF
--- a/src/routes/game/game.scss
+++ b/src/routes/game/game.scss
@@ -137,8 +137,8 @@ h1 {
   list-style: none;
   padding: 0;
   margin: 1rem 0;
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   justify-content: center;
   align-items: stretch;
   gap: 1.25rem;
@@ -149,8 +149,7 @@ h1 {
     justify-content: center;
     border: 2px solid transparent;
     padding: 0.25rem;
-    flex: 1 1 220px;
-    min-width: 180px;
+    min-width: 0;
     gap: 0.75rem;
   }
 
@@ -182,6 +181,8 @@ h1 {
   display: flex;
   align-items: center;
   gap: 1rem;
+  flex: 1;
+  flex-wrap: wrap;
   border: 2px solid transparent;
   padding: 0.5rem;
   border-radius: 4px;
@@ -190,7 +191,9 @@ h1 {
   input {
     font: inherit;
     font-size: 1rem;
-    width: 10rem;
+    flex: 1 1 10rem;
+    min-width: 0;
+    max-width: 100%;
     border: none;
     padding: 0.5rem;
     animation: pulse-text 2s infinite;
@@ -202,7 +205,8 @@ h1 {
 
 .player-name {
   display: inline-block;
-  width: 10rem;
+  flex: 1 1 10rem;
+  min-width: 0;
   font-size: 1rem;
   color: var(--text-muted);
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- switch the players container to a responsive CSS grid so both cards stay on one row when space allows and stack only when narrow
- let each player card shrink inside the grid without forcing an extra column

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920f2e960708330ab1d6acc46c3516e)